### PR TITLE
windows環境での立ち上げエラー解消

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,8 @@
 import { resolve } from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 
 
 export default (({ mode }) => {
-  process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
   const lessonName = process.env.LESSON_NAME;
 
   return defineConfig({


### PR DESCRIPTION
## やったこと
https://github.com/gizumo-education/sass-lesson/issues/3

## やらないこと
なし

## 動作確認
windows、mac両方の環境で`npm i` → `npm run dev:practice` , `npm run dev:puzzle`を実行し、エラーなく開発サーバーが立ち上がること